### PR TITLE
feat(nav): widen navbar to align with main content borders

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -47,8 +47,8 @@ export function Navigation({ activeSection = 0, usesScroll = false }: Navigation
 
   return (
     <nav className='fixed top-0 left-0 right-0 z-50 xl:backdrop-blur-md xl:bg-white/10'>
-      <div className='px-4'>
-        <div className='h-16 flex items-center xl:grid xl:grid-cols-[15%_70%_15%]'>
+      <div className='px-4 xl:px-10'>
+        <div className='h-16 flex items-center xl:grid xl:grid-cols-[auto_1fr_auto] xl:gap-x-6'>
           {/* Logo */}
           <div className='flex items-center'>
             {(showRightMenu || isLargeScreen) && (


### PR DESCRIPTION
Increase horizontal padding at xl breakpoint (px-4 → px-10) and switch grid columns from fixed percentages [15%_70%_15%] to [auto_1fr_auto] with a gap, so the logo and buttons sit at the content left/right edges (matching the px-10 padding used by non-hero sections) and the center pill expands to fill the remaining space.