### PR TITLE
feat(testimonials): add COIB testimonial

### DIFF
--- a/lib/testimonials-data.ts
+++ b/lib/testimonials-data.ts
@@ -6,6 +6,7 @@ import logoBellpuigColour from '@/assets/logos/logo_bellpuig_colour.webp'
 import logoBisbalRound from '@/assets/logos/logo_bisbal_round.webp'
 import logoBloockColour from '@/assets/logos/logo_bloock_colour.webp'
 import logoCecColour from '@/assets/logos/logo_cec_colour.webp'
+import logoCoibRound from '@/assets/logos/logo_coib_round.webp'
 import logoEicColour from '@/assets/logos/logo_eic_colour.webp'
 import logoIcoesColour from '@/assets/logos/logo_icoes_colour.webp'
 import logoOmniumColour from '@/assets/logos/logo_omnium_colour.webp'
@@ -176,6 +177,20 @@ export function getTestimonialsData(t: TFunction): Testimonial[] {
       platformName: 'ICOES',
       platformImage: logoIcoesColour,
       logo: logoIcoesRound,
+    },
+    {
+      name: 'Lluis Serrat i Andreu',
+      handle: t('testimonials_marquee.items.10.handle', 'Head of projects · Official College of Nurses of Barcelona'),
+      avatar: '/images/avatars/avatar-7.png',
+      rating: 5,
+      title: t('testimonials_marquee.items.10.title', 'Fast, simple, and reliable participation'),
+      content: t(
+        'testimonials_marquee.items.10.content',
+        'At the Official College of Nurses of Barcelona, we trust Vocdoni for all our participatory processes, ensuring members can exercise their rights from anywhere. We especially value the immediate vote count, the simplicity of the system, and the fast, effective response and guidance from its technical support, which makes the entire process agile, transparent, and reliable.'
+      ),
+      platformName: 'COIB',
+      platformImage: logoCoibRound,
+      logo: logoCoibRound,
     },
   ]
 }

--- a/locales/ca/common.json
+++ b/locales/ca/common.json
@@ -753,6 +753,11 @@
         "content": "La digitalització de les nostres votacions amb Vocdoni ha millorat l'eficiència de tot el procés electoral. Hem aconseguit facilitar enormement la participació, especialment dels col·legiats que no es podien desplaçar, mantenint alhora un sistema àgil i fiable.",
         "handle": "President · Col·legi Oficial d'Infermeria de Sevilla",
         "title": "Votacions més eficients i accessibles"
+      },
+      "10": {
+        "content": "Al Col·legi Oficial d'Infermeres i Infermers de Barcelona confiem en Vocdoni per a tots els nostres processos participatius, garantint que les col·legiades puguin exercir el seu dret des de qualsevol lloc. Valorem especialment la immediatesa en el recompte dels vots, la simplicitat del sistema, i la ràpida i eficaç resposta i acompanyament del seu suport tècnic, cosa que fa que tot el procés sigui àgil, transparent i fiable.",
+        "handle": "Cap de projectes · Col·legi Oficial d'Infermeres i Infermers de Barcelona",
+        "title": "Participació ràpida, senzilla i fiable"
       }
     }
   },

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -753,6 +753,11 @@
         "content": "Digitizing our voting with Vocdoni has made the entire electoral process more efficient. We have made participation much easier, especially for members who could not travel, while maintaining an agile and reliable system.",
         "handle": "President · Official College of Nursing of Seville",
         "title": "More efficient and accessible voting"
+      },
+      "10": {
+        "content": "At the Official College of Nurses of Barcelona, we trust Vocdoni for all our participatory processes, ensuring members can exercise their rights from anywhere. We especially value the immediate vote count, the simplicity of the system, and the fast, effective response and guidance from its technical support, which makes the entire process agile, transparent, and reliable.",
+        "handle": "Head of projects · Official College of Nurses of Barcelona",
+        "title": "Fast, simple, and reliable participation"
       }
     }
   },

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -753,6 +753,11 @@
         "content": "La digitalización de nuestras votaciones con Vocdoni ha mejorado la eficiencia de todo el proceso electoral. Hemos conseguido facilitar enormemente la participación, especialmente de aquellos colegiados que no podían desplazarse, manteniendo al mismo tiempo un sistema ágil y fiable.",
         "handle": "Presidente · Colegio Oficial de Enfermería de Sevilla",
         "title": "Votaciones más eficientes y accesibles"
+      },
+      "10": {
+        "content": "En el Colegio Oficial de Enfermeras y Enfermeros de Barcelona confiamos en Vocdoni para todos nuestros procesos participativos, garantizando que las colegiadas puedan ejercer su derecho desde cualquier lugar. Valoramos especialmente la inmediatez en el recuento de los votos, la simplicidad del sistema y la respuesta y acompañamiento rápidos y eficaces de su soporte técnico, lo que hace que todo el proceso sea ágil, transparente y fiable.",
+        "handle": "Jefe de proyectos · Colegio Oficial de Enfermeras y Enfermeros de Barcelona",
+        "title": "Participación rápida, sencilla y fiable"
       }
     }
   },


### PR DESCRIPTION
## Summary

- Added the COIB testimonial to the main landing page testimonials block.
- Localized the testimonial copy in Catalan, English, and Spanish using the existing `testimonials_marquee` i18n keys.
- Reused the existing COIB logo asset for the testimonial card.

## Validation

- [x] `pnpm validate`
- [x] commit format follows the repo convention
- [x] user-facing copy uses `react-i18next`
- [x] `pnpm translations` was run or `pnpm guardrails:translations` passes cleanly
- [x] new components follow the repo folder policy