### PR TITLE
fix(contact): update contact links

### DIFF
--- a/components/shadcn-studio/blocks/contact-us-page-02/contact-us-page-02.tsx
+++ b/components/shadcn-studio/blocks/contact-us-page-02/contact-us-page-02.tsx
@@ -108,10 +108,10 @@ const ContactUs = () => {
                         <div>
                           <Link
                             className='text-lg font-bold hover:underline decoration-2 underline-offset-2 transition-all'
-                            href='mailto:contact@vocdoni.io'
+                            href='mailto:contact@vocdoni.org'
                             variant='unstyled'
                           >
-                            contact@vocdoni.io
+                            contact@vocdoni.org
                           </Link>
                           <p className='text-sm opacity-75 mt-1'>
                             {t('contact.email_response_time', 'We typically respond within 24 hours')}

--- a/pages/index/+Page.tsx
+++ b/pages/index/+Page.tsx
@@ -54,7 +54,7 @@ export default function Page() {
         'landing.portfolio.items.3.description',
         'Full expert support for complex governance, from initial configuration to certified verifiable results.'
       ),
-      link: '#',
+      link: '/contact',
       imageUrl: customProjectImg,
       imageAlt: 'Data charts and project management',
       imageWrapperClassName: 'px-4 sm:px-8 pt-12 lg:pt-14',
@@ -70,7 +70,7 @@ export default function Page() {
         'landing.portfolio.items.4.description',
         'A solution to collect signatures and sign petitions that uses a privacy-first and data-minimization app called Vocdoni Passport.'
       ),
-      link: '#',
+      link: '/contact',
       imageUrl: vocdoniPetitionsImg,
       imageAlt: 'Vocdoni Petitions and Passport app',
       imageWrapperClassName: 'px-4 sm:px-8 pt-4 sm:pt-6 lg:pt-8',


### PR DESCRIPTION
## Summary

- Updated the contact landing direct email from `contact@vocdoni.io` to `contact@vocdoni.org`.
- Redirected the main landing “custom election projects” and “Vocdoni Petitions” solution cards to the contact page.

## Validation

- [x] `pnpm validate`
- [x] commit format follows the repo convention
- [x] user-facing copy uses `react-i18next`
- [x] `pnpm translations` was run or `pnpm guardrails:translations` passes cleanly
- [x] new components follow the repo folder policy