### PR TITLE
feat(i18n): refine Italian translation copy

### DIFF
--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -1,17 +1,17 @@
 {
   "about_us": {
-    "content_description": "Dal 2018, Vocdoni (dall'esperanto, «dare voce») permette alle organizzazioni di tenere elezioni con integrità matematica. Offriamo il sistema di voto più verificabile al mondo, spostando la fiducia dalle promesse del fornitore a una prova pubblica verificabile.",
+    "content_description": "Dal 2018, Vocdoni (dall'esperanto, «dare voce») aiuta le organizzazioni a gestire elezioni con integrità matematica. Offriamo il sistema di voto più verificabile al mondo, spostando la fiducia dalle promesse del fornitore a una prova pubblica verificabile.",
     "content_title": "La fiducia non è una promessa. È una proprietà strutturale.",
-    "description": "Dai comuni e dai partiti politici fino ad associazioni e cooperative, Vocdoni (dall'esperanto, «dare voce») è nata per pareggiare le condizioni di partenza. Il nostro obiettivo è semplice: offrire la migliore e più sicura tecnologia di voto digitale a qualsiasi organizzazione, indipendentemente dalle dimensioni.",
+    "description": "Dai comuni e dai partiti politici fino ad associazioni e cooperative, Vocdoni (dall'esperanto, «dare voce») è nata per rendere il voto digitale sicuro accessibile a tutti. Il nostro obiettivo è semplice: offrire la migliore e più sicura tecnologia di voto digitale a qualsiasi organizzazione, indipendentemente dalle dimensioni.",
     "eyebrow": "Su Vocdoni",
     "feature_cards": {
       "accessibility": {
-        "description": "Qualsiasi organizzazione al mondo, da un club sportivo di 20 persone a un ente civico con 200.000 membri, può tenere oggi un'elezione con lo stesso livello di qualità.",
+        "description": "Qualsiasi organizzazione al mondo, da un club sportivo di 20 persone a un'organizzazione civica con 200.000 membri, può organizzare oggi un'elezione con lo stesso livello di qualità.",
         "title": "Governance accessibile"
       },
       "compliance": {
-        "description": "Ogni elezione include una traccia di audit completa, un documento dei risultati certificato e una prova pubblica su cui il tuo team legale può contare.",
-        "title": "Legalmente valida per progettazione"
+        "description": "Ogni elezione include una traccia di audit completa, un verbale dei risultati certificato e una prova pubblica su cui il tuo team legale può contare.",
+        "title": "Validità legale fin dalla progettazione"
       },
       "security": {
         "description": "Ogni membro, osservatore o revisore indipendente può verificare il risultato completo senza vedere un singolo voto. Il nostro codice è pubblico. Non abbiamo nulla da nascondere.",
@@ -37,7 +37,7 @@
         "title": "30%"
       },
       "votes": {
-        "description": "Voti elaborati in modo sicuro dal nostro protocollo",
+        "description": "Voti gestiti in sicurezza dal nostro protocollo",
         "title": "200.000+"
       }
     },
@@ -49,16 +49,16 @@
     },
     "tabs": {
       "mission": {
-        "content": "Dare a ogni comunità una tecnologia di voto digitale sicura e verificabile come diritto fondamentale, non come lusso. Forniamo gli strumenti perché organizzazioni di qualsiasi dimensione possano tenere elezioni inattaccabili per progettazione.",
+        "content": "Dare a ogni comunità una tecnologia di voto digitale sicura e verificabile come diritto fondamentale, non come lusso. Forniamo gli strumenti perché organizzazioni di qualsiasi dimensione possano organizzare elezioni a prova di contestazione fin dalla progettazione.",
         "title": "Missione"
       },
       "values": {
-        "content": "Ci guidano tre principi fondamentali: Fiducia Dimostrabile (matematica al posto delle promesse), Semplicità Radicale (tecnologia sofisticata, interfaccia umana) e Apertura per Impostazione Predefinita (codice open source e prezzi pubblici).",
+        "content": "Ci guidano tre principi fondamentali: fiducia dimostrabile (matematica al posto delle promesse), semplicità radicale (tecnologia sofisticata, interfaccia umana) e apertura come principio di base (codice open source e prezzi pubblici).",
         "title": "I nostri valori"
       },
       "vision": {
-        "content": "Un futuro in cui i processi democratici siano trasparenti, inclusivi e a prova di manomissione per impostazione predefinita. Colmiamo il divario tra complessità tecnica e legittimità democratica perché ogni voce sia ascoltata e ogni voto conti.",
-        "content_2": "Forniamo gli strumenti perché organizzazioni di qualsiasi dimensione possano tenere elezioni inattaccabili per progettazione.",
+        "content": "Un futuro in cui i processi democratici siano trasparenti, inclusivi e a prova di manomissione per natura. Colmiamo il divario tra complessità tecnica e legittimità democratica perché ogni voce sia ascoltata e ogni voto conti.",
+        "content_2": "Forniamo gli strumenti perché organizzazioni di qualsiasi dimensione possano organizzare elezioni a prova di contestazione fin dalla progettazione.",
         "title": "Visione"
       }
     },
@@ -71,11 +71,11 @@
     "trust_section": {
       "cards": {
         "experience": {
-          "description": "Dal 2018, il team ha supportato progetti di governance digitale per comuni, associazioni, cooperative, partiti e comunità con membri.",
+          "description": "Dal 2018, il team ha supportato progetti di governance digitale per comuni, associazioni, cooperative, partiti e comunità associative.",
           "title": "Esperienza operativa"
         },
         "open_source": {
-          "description": "Vocdoni si basa su codice pubblico e su un lavoro di protocollo aperto, così che organizzazioni e revisori indipendenti possano ispezionare come le elezioni vengono create, espresse, contate e verificate.",
+          "description": "Vocdoni si basa su codice pubblico e su un lavoro di protocollo aperto, così che organizzazioni e revisori indipendenti possano ispezionare come le elezioni vengono configurate e come i voti vengono espressi, conteggiati e verificati.",
           "title": "Open source per impostazione predefinita"
         },
         "privacy": {
@@ -83,11 +83,11 @@
           "title": "Privacy e prontezza legale"
         },
         "verifiability": {
-          "description": "Ogni elezione può produrre prove pubbliche verificabili, verifica lato elettore e risultati che non dipendono da garanzie private del fornitore.",
+          "description": "Ogni elezione può produrre prove pubbliche verificabili, verifica da parte dell'elettore e risultati che non dipendono da garanzie private del fornitore.",
           "title": "Registri elettorali verificabili"
         }
       },
-      "description": "Vocdoni combina infrastruttura open source, verifica crittografica, processi rispettosi della privacy ed esperienza pratica nelle elezioni, così le organizzazioni possono tenere votazioni più facili da fidarsi e da spiegare.",
+      "description": "Vocdoni combina infrastruttura open source, verifica crittografica, processi rispettosi della privacy ed esperienza pratica nelle elezioni, così le organizzazioni possono organizzare votazioni di cui è più facile fidarsi e che sono più facili da spiegare.",
       "eyebrow": "Come si costruisce la fiducia",
       "title": "Infrastruttura di voto trasparente per decisioni importanti"
     }
@@ -96,7 +96,7 @@
     "cta": {
       "checklist_title": "Cosa ottieni dal primo giorno",
       "credit_card": "Nessuna carta di credito richiesta",
-      "description": "Avvia una vera votazione con il piano gratuito, vedi come funziona con i tuoi membri e passa a un piano a pagamento solo quando la tua organizzazione avrà bisogno di scalare.",
+      "description": "Avvia una vera votazione con il piano gratuito, vedi come funziona con i tuoi membri e passa a un piano a pagamento solo quando la tua organizzazione avrà bisogno di gestire più partecipanti.",
       "eyebrow": "Inizia senza attriti",
       "free": "Votazione gratuita fino a 100 membri",
       "pricing": "Prezzi pubblici per organizzazioni più grandi",
@@ -105,12 +105,12 @@
       "title": "La tua prossima votazione può essere attiva oggi"
     },
     "faq": {
-      "description": "Queste domande dovrebbero risolvere gli ultimi dubbi su prezzo, esperienza dell'elettore, fiducia, privacy, hosting e prove.",
+      "description": "Queste domande rispondono agli ultimi dubbi su prezzo, esperienza dell'elettore, fiducia, privacy, hosting e prove.",
       "eyebrow": "FAQ",
       "items": [
         {
-          "question": "Posso davvero tenere una votazione gratis?",
-          "answer": "Sì. Puoi tenere una votazione gratuita fino a 100 membri, senza carta di credito."
+          "question": "Posso davvero organizzare una votazione gratis?",
+          "answer": "Sì. Puoi organizzare una votazione gratuita fino a 100 membri, senza carta di credito."
         },
         {
           "question": "Quanto tempo serve per configurare una votazione?",
@@ -153,11 +153,11 @@
           "answer": "Sì. Puoi iniziare con un CSV o sincronizzarti tramite l'API se gestisci già i membri altrove."
         },
         {
-          "question": "Che tipi di votazione posso tenere?",
-          "answer": "Puoi tenere votazioni a scelta singola, a scelta multipla, ponderate, per approvazione, a punteggio e con più domande."
+          "question": "Che tipi di votazione posso organizzare?",
+          "answer": "Puoi organizzare votazioni a scelta singola, a scelta multipla, ponderate, per approvazione, a punteggio e con più domande."
         },
         {
-          "question": "Posso tenere anche votazioni in presenza o ibride?",
+          "question": "Posso organizzare anche votazioni in presenza o ibride?",
           "answer": "Sì. Vocdoni supporta votazioni a distanza, in presenza e ibride."
         },
         {
@@ -169,15 +169,15 @@
           "answer": "Puoi consultare la pagina sulla tecnologia, aprire l'esploratore pubblico delle votazioni e ispezionare il codice open source."
         }
       ],
-      "title": "Domande che gli acquirenti si pongono prima di iniziare"
+      "title": "Domande frequenti prima di iniziare"
     },
     "features": {
-      "description": "La sezione funzionalità deve restare compatta. La pagina deve dimostrare le capacità senza diventare un elenco infinito di prodotto.",
+      "description": "Funzionalità essenziali, senza complessità inutili.",
       "eyebrow": "Prova delle funzionalità",
       "items": [
         {
           "title": "Metodi di voto flessibili",
-          "description": "Tieni schede a scelta singola, a scelta multipla, ponderate, per approvazione, a punteggio e con più domande dalla stessa app."
+          "description": "Gestisci schede a scelta singola, a scelta multipla, ponderate, per approvazione, a punteggio e con più domande dalla stessa app."
         },
         {
           "title": "Autenticazione via email, SMS e 2FA",
@@ -200,7 +200,7 @@
           "description": "Ripeti più velocemente le votazioni ricorrenti e dai a ogni persona il livello di accesso giusto."
         }
       ],
-      "title": "Tutto quello che ti serve per tenere una vera elezione"
+      "title": "Tutto quello che ti serve per organizzare una vera elezione"
     },
     "outcomes": {
       "description": "Dai alla tua organizzazione un flusso di voto semplice da lanciare, semplice da completare e abbastanza solido da reggere anche dopo la chiusura delle urne.",
@@ -230,14 +230,14 @@
         "description": "Un ordine professionale regolato ha portato online la propria votazione annuale, ha mantenuto un'esperienza semplice per i membri e ha chiuso con risultati verificabili in modo indipendente.",
         "eyebrow": "Mini caso di studio",
         "link": "Leggi il caso di studio",
-        "title": "Come COIB ha tenuto la sua assemblea annuale online con risultati immediati e verificabili"
+        "title": "Come COIB ha organizzato la sua assemblea annuale online con risultati immediati e verificabili"
       },
-      "description": "La pagina deve combinare loghi, dati di prova, un caso concreto e le card delle testimonianze già usate nella landing principale.",
-      "eyebrow": "Riprova sociale",
+      "description": "Loghi, dati concreti, casi reali e testimonianze.",
+      "eyebrow": "Prova sociale",
       "stats": [
         {
           "value": "200.000+",
-          "label": "Voti elaborati in modo sicuro"
+          "label": "Voti gestiti in sicurezza"
         },
         {
           "value": "30%",
@@ -290,12 +290,12 @@
       "eyebrow": "La tecnologia dietro Vocdoni app",
       "items": [
         {
-          "title": "Privacy per progettazione",
+          "title": "Privacy fin dalla progettazione",
           "description": "I voti restano segreti pur essendo conteggiati correttamente, così la privacy non riduce la fiducia."
         },
         {
           "title": "Verificabile pubblicamente",
-          "description": "I risultati vivono su un registro pubblico che membri, revisori e osservatori possono ispezionare in modo indipendente."
+          "description": "I risultati sono registrati su un registro pubblico che membri, revisori e osservatori possono ispezionare in modo indipendente."
         },
         {
           "title": "Nessuna parte può alterare l'esito da sola",
@@ -313,7 +313,7 @@
     }
   },
   "comparison": {
-    "description": "La maggior parte degli strumenti di voto digitale ti chiede di fidarti dei loro risultati. Vocdoni ti dà prove. Vedi come ci confrontiamo.",
+    "description": "La maggior parte degli strumenti di voto digitale ti chiede di fidarti dei loro risultati. Vocdoni ti offre prove verificabili. Vedi come ci confrontiamo.",
     "eyebrow": "Confronto",
     "feature_column_label": "Caratteristica",
     "featureLabels": {
@@ -348,7 +348,7 @@
         "name": "Vocdoni",
         "privacySecurity": "Anonima e con integrità decentralizzata",
         "remoteAccessibility": "Vota da qualunque luogo, con qualunque dispositivo",
-        "scalability": "Scala illimitata, portata globale",
+        "scalability": "Scalabilità illimitata, portata globale",
         "sustainability": "Senza carta e a basso impatto",
         "transparency": "Open source e verificabile da chiunque"
       }
@@ -370,7 +370,7 @@
       "name_required": "Il nome è obbligatorio",
       "subject_required": "L'oggetto è obbligatorio"
     },
-    "get_in_touch_description": "Scegli il modo migliore per metterti in contatto con il nostro team. Siamo qui per rispondere alle tue domande e parlare di come Vocdoni può aiutare la tua organizzazione.",
+    "get_in_touch_description": "Scegli il modo migliore per contattare il nostro team. Siamo qui per rispondere alle tue domande e parlare di come Vocdoni può aiutare la tua organizzazione.",
     "get_in_touch_title": "Contattaci",
     "message": "Messaggio",
     "message_placeholder": "Raccontaci le tue esigenze di voto o di governance...",
@@ -380,14 +380,14 @@
     "organization": "Organizzazione",
     "organization_placeholder": "La tua azienda o organizzazione",
     "page_eyebrow": "Contatti",
-    "page_subtitle": "Sia che tu abbia bisogno di un voto sicuro per la tua organizzazione, sia che tu abbia domande sulla nostra piattaforma, siamo qui per aiutarti. Scrivici e costruiamo insieme il futuro della governance digitale.",
+    "page_subtitle": "Se hai bisogno di un voto sicuro per la tua organizzazione o hai domande sulla nostra piattaforma, siamo qui per aiutarti. Scrivici e costruiamo insieme il futuro della governance digitale.",
     "page_title": "Parliamo delle tue esigenze di governance",
     "schedule_call_button": "Prenota una chiamata",
     "sending": "Invio in corso...",
     "subject": "Oggetto",
     "subject_placeholder": "Come possiamo aiutarti?",
     "submit_button": "Invia messaggio",
-    "success": "Messaggio inviato con successo! Ti risponderemo presto.",
+    "success": "Messaggio inviato con successo. Ti risponderemo presto.",
     "whatsapp_button": "Chatta su WhatsApp"
   },
   "cookies": {
@@ -399,7 +399,7 @@
     "title": "Consenso ai cookie"
   },
   "cta": {
-    "button": "Inizia a votare gratis",
+    "button": "Inizia gratis",
     "description": "Che tu stia sostituendo le schede cartacee o lasciando un sistema con poca trasparenza, Vocdoni ti porta a destinazione. Configura la tua prima elezione gratis: nessuna chiamata, nessuna carta di credito, nessun progetto di implementazione.",
     "image_alt": "Griglia di mockup di siti web",
     "title": "I tuoi membri meritano una votazione di cui fidarsi"
@@ -414,7 +414,7 @@
   },
   "faq": {
     "cta_button": "Inizia gratis",
-    "cta_title": "Pronto a vederlo con i tuoi occhi?",
+    "cta_title": "Vuoi vederlo con i tuoi occhi?",
     "eyebrow": "FAQ",
     "items": {
       "accessibility": {
@@ -430,15 +430,15 @@
         "question": "Posso usare l'elenco elettori o il CRM esistente?"
       },
       "coercion": {
-        "answer": "Vocdoni supporta la revisione del voto: i membri possono cambiare scelta tutte le volte che vogliono mentre la votazione è aperta. Conta solo l'ultima scelta, il che aiuta a mitigare la coercizione negli ambienti digitali.",
+        "answer": "Vocdoni permette di modificare il voto: i membri possono cambiare scelta tutte le volte che vogliono mentre la votazione è aperta. Conta solo l'ultima scelta, il che aiuta a mitigare la coercizione negli ambienti digitali.",
         "question": "Qualcuno può costringere un membro a votare in un certo modo?"
       },
       "dispute": {
-        "answer": "Il risultato è memorizzato su un registro pubblico inalterabile. Ogni membro può verificarlo in modo indipendente - non chiedendolo a Vocdoni, ma controllando direttamente la prova pubblica. In sette anni di elezioni, nessun risultato di Vocdoni è mai stato contestato con successo per motivi di integrità.",
+        "answer": "Il risultato è memorizzato su un registro pubblico inalterabile. Ogni membro può verificarlo in modo indipendente - non chiedendolo a Vocdoni, ma verificando direttamente la prova pubblica. In sette anni di elezioni, nessun risultato di Vocdoni è mai stato contestato con successo per motivi di integrità.",
         "question": "Cosa succede se un membro contesta il risultato?"
       },
       "free": {
-        "answer": "Sì, fino a 100 membri, senza carta di credito e senza limite di tempo. Puoi tenere oggi una vera elezione e vedere come funziona prima di impegnarti. I prezzi per organizzazioni più grandi sono pubblici sul nostro sito. Nessuna chiamata commerciale necessaria.",
+        "answer": "Sì, fino a 100 membri, senza carta di credito e senza limite di tempo. Puoi organizzare oggi una vera elezione e vedere come funziona prima di impegnarti. I prezzi per organizzazioni più grandi sono pubblici sul nostro sito. Nessuna chiamata commerciale necessaria.",
         "question": "Vocdoni è gratis?"
       },
       "gdpr": {
@@ -446,11 +446,11 @@
         "question": "È conforme al GDPR?"
       },
       "hybrid": {
-        "answer": "Sì. Vocdoni supporta votazioni a distanza, in presenza e ibride, permettendoti di gestire tutta la partecipazione tramite un'unica fonte di verità.",
-        "question": "Posso tenere anche votazioni in presenza o ibride?"
+        "answer": "Sì. Vocdoni supporta votazioni a distanza, in presenza e ibride, permettendoti di gestire tutta la partecipazione tramite un unico registro affidabile.",
+        "question": "Posso organizzare anche votazioni in presenza o ibride?"
       },
       "legal": {
-        "answer": "Vocdoni produce una traccia di audit completa e verificabile in modo indipendente, oltre a un documento dei risultati certificato per ogni elezione. Per la maggior parte degli ordini professionali, delle associazioni e delle cooperative in Europa, questo soddisfa i requisiti tecnici per un'elezione online valida. Se la tua organizzazione ha requisiti statutari specifici, verificali con il tuo consulente legale - e contattaci se hai bisogno di documentazione.",
+        "answer": "Vocdoni produce una traccia di audit completa e verificabile in modo indipendente, oltre a un verbale dei risultati certificato per ogni elezione. Per la maggior parte degli ordini professionali, delle associazioni e delle cooperative in Europa, questo soddisfa i requisiti tecnici per un'elezione online valida. Se la tua organizzazione ha requisiti statutari specifici, verificali con il tuo consulente legale - e contattaci se hai bisogno di documentazione.",
         "question": "I risultati elettorali sono legalmente validi?"
       },
       "open_source": {
@@ -470,12 +470,12 @@
         "question": "Come faccio a sapere che il risultato non è stato manomesso?"
       },
       "techsavvy": {
-        "answer": "Gli elettori ricevono un link. Ci cliccano, vedono la scheda, fanno la loro scelta e la inviano. Nessun account, nessuna app da scaricare, nessuna password. Se funziona sul browser di uno smartphone, funziona per i tuoi membri.",
+        "answer": "Gli elettori ricevono un link. Ci cliccano, visualizzano la scheda elettorale, fanno la loro scelta e la inviano. Nessun account, nessuna app da scaricare, nessuna password. Se funziona sul browser di uno smartphone, funziona per i tuoi membri.",
         "question": "E se alcuni dei nostri membri non sono molto pratici di tecnologia?"
       },
       "vote_types": {
-        "answer": "Puoi tenere votazioni a scelta singola, a scelta multipla, ponderate, per approvazione, a punteggio e con più domande dalla stessa piattaforma.",
-        "question": "Che tipi di votazione posso tenere?"
+        "answer": "Puoi organizzare votazioni a scelta singola, a scelta multipla, ponderate, per approvazione, a punteggio e con più domande dalla stessa piattaforma.",
+        "question": "Che tipi di votazione posso organizzare?"
       },
       "voters_app": {
         "answer": "No. Gli elettori aprono un link nel browser e votano da qualsiasi dispositivo. Nessun account o password richiesti.",
@@ -557,7 +557,7 @@
       "sicuro",
       "semplice"
     ],
-    "subtitle": "Tieni elezioni sicure e legalmente valide da qualsiasi dispositivo. Qualsiasi organizzazione, qualsiasi dimensione, da oggi.",
+    "subtitle": "Organizza elezioni sicure e legalmente valide da qualsiasi dispositivo. Qualsiasi organizzazione, qualsiasi dimensione, da oggi.",
     "title": "Prendere decisioni non è mai stato così",
     "trusted_by": "Scelta da organizzazioni di ogni dimensione"
   },
@@ -603,7 +603,7 @@
       "title": "Contatti - Vocdoni"
     },
     "index": {
-      "description": "Tieni elezioni sicure e legalmente valide per la tua organizzazione con la tecnologia di voto più verificabile. Inizia gratis, configura in pochi minuti, senza carta di credito.",
+      "description": "Organizza elezioni sicure e legalmente valide per la tua organizzazione con la tecnologia di voto più verificabile. Inizia gratis, configura in pochi minuti, senza carta di credito.",
       "title": "Vocdoni - Voto online sicuro e verificabile"
     },
     "privacy": {
@@ -682,11 +682,11 @@
   },
   "steps_section": {
     "label": "Configura una votazione in meno di 10 minuti",
-    "panel_description": "Vocdoni si occupa della sicurezza. Tu ti occupi delle domande.",
+    "panel_description": "Vocdoni gestisce la sicurezza. Tu ti occupi delle domande.",
     "panel_title": "Dal foglio di calcolo all'elezione in diretta in pochi minuti",
     "steps": {
       "create": {
-        "description": "Scegli il metodo di voto, scrivi la domanda e imposta date di inizio e fine. La tua scheda è configurata e pronta in meno di cinque minuti.",
+        "description": "Scegli il metodo di voto, scrivi la domanda e imposta date di inizio e fine. La tua scheda elettorale è pronta in meno di cinque minuti.",
         "title": "2. Crea il processo di voto"
       },
       "share": {
@@ -698,7 +698,7 @@
         "title": "1. Carica l'elenco dei membri"
       }
     },
-    "subtitle": "Niente configurazione tecnica, niente burocrazia. Carica i membri, costruisci la scheda e condividi il link - basta questo.",
+    "subtitle": "Niente configurazione tecnica, niente burocrazia. Carica i membri, crea la scheda elettorale e condividi il link - basta questo.",
     "title_highlight": "tre passi",
     "title_start": "La tua prima elezione sicura, attiva in"
   },
@@ -746,7 +746,7 @@
         "title": "Voto digitale trasparente, sicuro e flessibile per i cittadini"
       },
       "8": {
-        "content": "La transizione al voto elettronico sta diventando inevitabile, dato che la società è digitalmente più pronta che mai. Grazie alla collaborazione tra BLOOCK e Vocdoni, stiamo rendendo possibile una partecipazione civica più significativa e continua nel governo e nelle istituzioni.",
+        "content": "La transizione al voto elettronico sta diventando inevitabile, dato che la società è più pronta che mai al digitale. Grazie alla collaborazione tra BLOOCK e Vocdoni, stiamo rendendo possibile una partecipazione civica più significativa e continua nel governo e nelle istituzioni.",
         "handle": "Fondatore e CEO · BLOOCK",
         "title": "Rendere possibile una partecipazione civica significativa"
       },
@@ -778,16 +778,16 @@
       "impact_label": "Impatto",
       "items": {
         "associations": {
-          "description": "Tieni elezioni del consiglio, modifiche allo statuto e assemblee statutarie nel rispetto delle regole della tua organizzazione. Ogni membro riceve un link per verificare che il proprio voto sia stato conteggiato - senza rivelare come ha votato.",
+          "description": "Organizza elezioni del consiglio, modifiche allo statuto e assemblee statutarie nel rispetto delle regole della tua organizzazione. Ogni membro riceve un link per verificare che il proprio voto sia stato conteggiato - senza rivelare come ha votato.",
           "features": [
             "Elezioni dei membri del consiglio",
             "Modifiche allo statuto",
             "Approvazione di iniziative importanti"
           ],
-          "title": "Associazioni e organizzazioni di membri"
+          "title": "Associazioni e organizzazioni di soci"
         },
         "city_councils": {
-          "description": "Tieni referendum vincolanti, bilanci partecipativi e consultazioni pubbliche che qualsiasi residente può verificare. I risultati vengono pubblicati su un registro pubblico inalterabile - nessuna parte, inclusa Vocdoni, può modificarli.",
+          "description": "Gestisci referendum vincolanti, bilanci partecipativi e consultazioni pubbliche che qualsiasi residente può verificare. I risultati vengono pubblicati su un registro pubblico inalterabile - nessuna parte, inclusa Vocdoni, può modificarli.",
           "features": [
             "Referendum locali e votazioni vincolanti",
             "Bilanci partecipativi",
@@ -805,7 +805,7 @@
           "title": "Integratori software e fornitori di piattaforme"
         },
         "political_parties": {
-          "description": "Tieni primarie e votazioni degli iscritti in cui nessuna parte - nemmeno Vocdoni - può manipolare il risultato. Gli elettori non possono essere costretti: possono cambiare il voto in qualsiasi momento prima della chiusura.",
+          "description": "Gestisci primarie e votazioni degli iscritti in cui nessuna parte - nemmeno Vocdoni - può manipolare il risultato. Gli elettori non possono essere costretti: possono cambiare il voto in qualsiasi momento prima della chiusura.",
           "features": [
             "Elezioni della leadership e primarie interne",
             "Infrastruttura neutrale e resistente alla censura",
@@ -823,7 +823,7 @@
           "title": "Ordini e associazioni professionali"
         },
         "sports_clubs": {
-          "description": "Gestisci elezioni di club e decisioni dei soci per migliaia di tifosi in tutto il mondo. Qualsiasi socio internazionale può votare da qualsiasi dispositivo. I risultati sono verificabili pubblicamente: un link e chiunque può controllare.",
+          "description": "Gestisci elezioni di club e decisioni dei soci per migliaia di tifosi in tutto il mondo. Qualsiasi socio internazionale può votare da qualsiasi dispositivo. I risultati sono verificabili pubblicamente: basta un link e chiunque può verificarli.",
           "features": [
             "Elezioni delle cariche del club",
             "Approvazione di spese rilevanti",
@@ -853,8 +853,8 @@
           "label": "Partecipazione media"
         }
       ],
-      "subtitle": "Dai comuni ai club sportivi, dagli ordini professionali ai partiti politici - scopri come organizzazioni di tutta Europa usano Vocdoni per tenere elezioni sicure e verificabili. Risultati che ogni membro può controllare in modo indipendente. Si configura in un pomeriggio.",
-      "title": "Come le organizzazioni tengono elezioni di cui i loro membri possono fidarsi"
+      "subtitle": "Dai comuni ai club sportivi, dagli ordini professionali ai partiti politici - scopri come organizzazioni di tutta Europa usano Vocdoni per organizzare elezioni sicure e verificabili. Risultati che ogni membro può verificare in modo indipendente. Si configura in un pomeriggio.",
+      "title": "Come le organizzazioni gestiscono elezioni di cui i loro membri possono fidarsi"
     },
     "success_stories": {
       "eyebrow": "Casi di successo",
@@ -884,7 +884,7 @@
             {
               "value": "Ibrido",
               "label": "Formato",
-              "description": "Online + Supporto in presenza"
+              "description": "Online + supporto in presenza"
             },
             {
               "value": "OCSE",
@@ -911,17 +911,17 @@
             {
               "value": "50 €",
               "label": "Risparmio di viaggio",
-              "description": "Per iscritto"
+              "description": "Per membro"
             },
             {
               "value": "2FA",
               "label": "Sicurezza",
-              "description": "Autenticazione SMS/Email"
+              "description": "Autenticazione SMS/email"
             },
             {
               "value": "Ibrido",
               "label": "Partecipazione",
-              "description": "In presenza + Remoto"
+              "description": "In presenza + remoto"
             }
           ]
         },
@@ -945,7 +945,7 @@
             "Gli elettori possono cambiare il voto",
             "Schede anonime ma verificabili"
           ],
-          "impact": "Votazione decisiva degli iscritti su una questione con conseguenze politiche significative. Una prova che il voto sicuro e verificabile su decisioni ad alta posta in gioco può scalare senza incidenti.",
+          "impact": "Votazione decisiva degli iscritti su una questione con conseguenze politiche significative. Una prova che il voto sicuro e verificabile su decisioni ad alta posta in gioco può funzionare su larga scala senza incidenti.",
           "industry": "Partito politico",
           "org": "Esquerra Republicana de Catalunya (ERC)",
           "quote": "Esquerra Republicana ha usato Vocdoni per una votazione decisiva degli iscritti con il 77,12% di partecipazione e risultati disponibili pochi secondi dopo la chiusura.",
@@ -975,7 +975,7 @@
             "Resistente alle interferenze governative",
             "Segretezza crittografica come dato di fatto",
             "Supervisionato da osservatori internazionali",
-            "Neutralità strutturale per progettazione"
+            "Neutralità strutturale fin dalla progettazione"
           ],
           "impact": "Elezioni per il Consiglio di Coordinamento che riunisce le organizzazioni democratiche che non possono operare in sicurezza dentro la Bielorussia. La resistenza alla censura non era un vantaggio, ma una necessità.",
           "industry": "Movimento politico",
@@ -1010,10 +1010,10 @@
       "cta_primary": "Inizia gratis",
       "cta_secondary": "Guarda la demo",
       "subtitle": "Configura, invia e raccogli voti in pochi minuti - da qualsiasi dispositivo, con piena validità legale e traccia di audit.",
-      "title": "Tieni la tua votazione online,",
+      "title": "Gestisci la tua votazione online,",
       "title_highlight": "in piena fiducia",
       "trust_gdpr": "Conforme al GDPR",
-      "trust_legal": "Prova legale",
+      "trust_legal": "Validità legale",
       "video_play": "Riproduci video demo"
     },
     "target_users": {
@@ -1049,7 +1049,7 @@
         },
         "risk_reduction": {
           "description": "Elimina errori, contestazioni e violazioni della sicurezza con tecnologia verificabile.",
-          "title": "Rischio zero"
+          "title": "Riduzione del rischio"
         }
       },
       "title": "Perché Vocdoni?"


### PR DESCRIPTION
## Summary

- Refined the Italian translation copy in `locales/it/common.json` for more natural SaaS and digital voting language.

## Validation

- [x] `pnpm validate`
- [x] commit format follows the repo convention
- [x] user-facing copy uses `react-i18next`
- [x] `pnpm translations` was run or `pnpm guardrails:translations` passes cleanly
- [x] new components follow the repo folder policy
